### PR TITLE
Use int instead of removed union wait type

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -193,7 +193,7 @@ void handle_quit_signal(int signum)
 /* handler for reaping children after the fork is done. */
 void handle_child_signal()
 {
-    union wait status;
+    int status;
     while (wait3(&status, WNOHANG, 0) > 0) {} 
 }
 


### PR DESCRIPTION
The union wait type was removed in glibc 2.24, and it's recommended to use the int type instead. Fixes #11.